### PR TITLE
update to v0.4 tuple syntax using @compat macro

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -3,3 +3,4 @@ StatsBase
 Distributions 0.4.6
 Optim
 Grid
+Compat

--- a/src/KernelDensity.jl
+++ b/src/KernelDensity.jl
@@ -4,6 +4,7 @@ using StatsBase
 using Distributions
 using Optim
 using Grid
+using Compat
 
 import Base: conv
 import StatsBase: RealVector, RealMatrix

--- a/src/univariate.jl
+++ b/src/univariate.jl
@@ -58,7 +58,7 @@ function kde_boundary(data::RealVector, bandwidth::Real)
 end
 
 # convert boundary and npoints to Range object
-function kde_range(boundary::(Real,Real), npoints::Int)
+function kde_range(boundary::(@compat Tuple{Real,Real}), npoints::Int)
     lo, hi = boundary
     lo < hi || error("boundary (a,b) must have a < b")
 
@@ -125,7 +125,7 @@ function kde(data::RealVector, midpoints::Range, dist::UnivariateDistribution)
 end
 
 function kde(data::RealVector, dist::UnivariateDistribution;
-             boundary::(Real,Real)=kde_boundary(data,std(dist)), npoints::Int=2048)
+             boundary::(@compat Tuple{Real,Real})=kde_boundary(data,std(dist)), npoints::Int=2048)
 
     midpoints = kde_range(boundary,npoints)
     kde(data,midpoints,dist)
@@ -139,7 +139,7 @@ function kde(data::RealVector, midpoints::Range;
 end
 
 function kde(data::RealVector; bandwidth=default_bandwidth(data), kernel=Normal,
-             npoints::Int=2048, boundary::(Real,Real)=kde_boundary(data,bandwidth))
+             npoints::Int=2048, boundary::(@compat Tuple{Real,Real})=kde_boundary(data,bandwidth))
     bandwidth > 0.0 || error("Bandwidth must be positive")
     dist = kernel_dist(kernel,bandwidth)
     kde(data,dist;boundary=boundary,npoints=npoints)
@@ -152,7 +152,7 @@ end
 
 function kde_lscv(data::RealVector, midpoints::Range;
                   kernel=Normal,
-                  bandwidth_range::(Real,Real)=(h=default_bandwidth(data); (0.25*h,1.5*h)))
+                  bandwidth_range::(@compat Tuple{Real,Real})=(h=default_bandwidth(data); (0.25*h,1.5*h)))
 
     ndata = length(data)
     k = tabulate(data, midpoints)
@@ -191,10 +191,10 @@ function kde_lscv(data::RealVector, midpoints::Range;
 end
 
 function kde_lscv(data::RealVector;
-                  boundary::(Real,Real)=kde_boundary(data,default_bandwidth(data)),
+                  boundary::(@compat Tuple{Real,Real})=kde_boundary(data,default_bandwidth(data)),
                   npoints::Int=2048,
                   kernel=Normal,
-                  bandwidth_range::(Real,Real)=(h=default_bandwidth(data); (0.25*h,1.5*h)))
+                  bandwidth_range::(@compat Tuple{Real,Real})=(h=default_bandwidth(data); (0.25*h,1.5*h)))
 
     midpoints = kde_range(boundary,npoints)
     kde_lscv(data,midpoints; kernel=kernel, bandwidth_range=bandwidth_range)

--- a/test/bivariate.jl
+++ b/test/bivariate.jl
@@ -1,12 +1,13 @@
 using Base.Test
 using Distributions
 using KernelDensity
+using Compat
 
 import KernelDensity: kernel_dist, default_bandwidth, kde_boundary, kde_range, tabulate
 
-for D in [(Normal,Normal),(Uniform,Uniform),(Logistic,Logistic)]
-    d = kernel_dist(D,(0.5,0.5))
-    @test isa(d,D)
+for D in [(@compat Tuple{Normal,Normal}),(@compat Tuple{Uniform,Uniform}),(@compat Tuple{Logistic,Logistic}),
+          (Normal, Normal), (Uniform, Uniform), (Logistic, Logistic)]
+    d = KernelDensity.kernel_dist(D,(0.5,0.5))
     dx,dy = d
     @test mean(dx) == 0.0
     @test mean(dy) == 0.0
@@ -17,7 +18,7 @@ end
 r = kde_range((-2.0,2.0), 128)
 @test step(r) > 0
 
-for X in ([0.0], [0.0,0.0], [0.0,0.5], [-0.5:0.1:0.5])
+for X in ([0.0], [0.0,0.0], [0.0,0.5], [-0.5:0.1:0.5;])
     w = default_bandwidth(X)
     @test w > 0
     lo, hi = kde_boundary(X,w)
@@ -32,7 +33,7 @@ for X in ([0.0], [0.0,0.0], [0.0,0.5], [-0.5:0.1:0.5])
         @test all(k1.density .>= 0.0)
         @test_approx_eq sum(k1.density)*step(k1.x)*step(k1.y) 1.0
 
-        k2 = conv(k1,kernel_dist((D,D),(0.1,0.1)))
+        k2 = conv(k1,kernel_dist((@compat Tuple{D,D}),(0.1,0.1)))
         @test isa(k2,BivariateKDE)
         @test size(k2.density) == (length(k2.x), length(k2.y))
         @test all(k2.density .>= 0.0)

--- a/test/univariate.jl
+++ b/test/univariate.jl
@@ -14,7 +14,7 @@ end
 r = kde_range((-2.0,2.0), 128)
 @test step(r) > 0
 
-for X in ([0.0], [0.0,0.0], [0.0,0.5], [-0.5:0.1:0.5])
+for X in ([0.0], [0.0,0.0], [0.0,0.5], [-0.5:0.1:0.5;])
     w = default_bandwidth(X)
     @test w > 0
     lo, hi = kde_boundary(X,w)


### PR DESCRIPTION
While trying to wander down the long road of getting `Gadfly` working in v0.4, I tried to update `KernelDensity` to use the new tuple syntax. Most of this is mechanical, and required only adding the `Compat` package. But this pull request does NOT result in a running package. there are still errors running the tests. In particular, type inference fails in a surprising way trying to evaluate `kernel_dist` with a tuple of distributions in its first argument. 

Where previously the code was dispatching on `::Type{(Dx,Dy)}`, the two obvious options both fail. One is `::Type{Tuple{Dx,Dy}}` but this doesn't seem quite right, and indeed doesn't even compile. The other is to take the tuple as a value, `_::Tuple{Dx,Dy}`, but while this compiles, methods that ought to satisfy the pattern don't. You can see the failures by including `test/bivariate.jl`