### PR TITLE
Updates for Julia 0.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,16 @@
 language: julia
 os:
-    - linux
-    - osx
+  - linux
+  - osx
 julia:
-    - 0.3
-    - 0.4
-    - nightly
+  - 0.3
+  - 0.4
+  - nightly
 notifications:
-    email: false
-sudo: false
+  email: false
+# Uncomment the following lines to override the default test script
+#script:
+#  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+#  - julia -e 'Pkg.clone(pwd()); Pkg.build("KernelDensity"); Pkg.test("KernelDensity"; coverage=true)'
+after_success:
+  - julia -e 'cd(Pkg.dir("KernelDensity")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # KernelDensity.jl
 
 [![Build Status](https://travis-ci.org/JuliaStats/KernelDensity.jl.svg?branch=master)](https://travis-ci.org/JuliaStats/KernelDensity.jl)
+[![Coverage Status](https://coveralls.io/repos/github/JuliaStats/KernelDensity.jl/badge.svg)](https://coveralls.io/github/JuliaStats/KernelDensity.jl)
 [![KernelDensity](http://pkg.julialang.org/badges/KernelDensity_0.3.svg)](http://pkg.julialang.org/?pkg=KernelDensity&ver=0.3)
 [![KernelDensity](http://pkg.julialang.org/badges/KernelDensity_0.4.svg)](http://pkg.julialang.org/?pkg=KernelDensity&ver=0.4)
+[![KernelDensity](http://pkg.julialang.org/badges/KernelDensity_0.5.svg)](http://pkg.julialang.org/?pkg=KernelDensity)
 
-Kernel density estimators for julia.
+Kernel density estimators for Julia.
 
 ## Usage
 


### PR DESCRIPTION
Looks like not much needs to change--might not even have to drop the 0.3 support?

Edit: Well, the only 0.5 deprecation warning will be gone once #31 is merged, so I guess nothing actually needs to change at all. So this PR is just adding 0.5 to CI and enabling coverage. ¯\\\_(ツ)\_/¯