### PR TITLE
Wrap around below

### DIFF
--- a/src/univariate.jl
+++ b/src/univariate.jl
@@ -93,10 +93,19 @@ function tabulate(data::RealVector, midpoints::Range, weights::Weights=default_w
     for (i,x) in enumerate(data)
         k = searchsortedfirst(midpoints,x)
         j = k-1
-        if 1 <= j <= npoints-1
-            grid[j] += (midpoints[k]-x)*ainc*weights[i]
-            grid[k] += (x-midpoints[j])*ainc*weights[i]
+        @assert j <= npoints -1
+        mid_above = midpoints[k]
+
+        if j >= 1
+            mid_below = midpoints[j]
+        if
+            @assert j==0
+            mid_below = midpoints[1] - s # Imaginary point outside boundry
+            j=npoints # Wrap around and allocate this to the top
         end
+        grid[j] += (mid_above-x)*ainc*weights[i]
+        grid[k] += (x-mid_below)*ainc*weights[i]
+
     end
 
     # returns an un-convolved KDE


### PR DESCRIPTION
I noticed that at https://github.com/JuliaStats/KernelDensity.jl/blob/bf4191d3eeada071d308b058c922b2aba6aa4003/src/univariate.jl#L96-L100
if a point should be allocated to the lower boundary it is just discarded.
Meaning after tabulate the bottom bin is always empty.

As I read the original Jones and Lotwick paper
https://www.jstor.org/stable/pdf/2347674.pdf
there solution in the equivalent case is to wrap-around.
Make sense as  the FFT-convolution will wrap around anyway


Now in most usage, the lower (and upper) bins should be sufficiently far from the edge,
so as to avoid wrap-around effects from FFT-convolution.
(I am running it to it because I am explicitly wanting wrap around effects).

Possible rather than employing wrap-around in tabulate,
the alternative might be to just throw an error in an `else` statement added to that `if`
Saying "Lower boundary too tight, please expand lower boundary"


This only handled the uni-variate case, if I am right it can be extended to the bivariate case