### PR TITLE
use improved high numerical precision linspace from Base

### DIFF
--- a/src/univariate.jl
+++ b/src/univariate.jl
@@ -66,8 +66,7 @@ function kde_range(boundary::Tuple{Real,Real}, npoints::Int)
     lo, hi = boundary
     lo < hi || error("boundary (a,b) must have a < b")
 
-    step = (hi - lo) / (npoints-1)
-    lo:step:hi
+    Compat.range(lo, stop=hi, length=npoints)
 end
 
 struct UniformWeights{N} end

--- a/test/univariate.jl
+++ b/test/univariate.jl
@@ -13,6 +13,8 @@ end
 
 r = kde_range((-2.0,2.0), 128)
 @test step(r) > 0
+r2 = kde_range((0.12698109160784082, 0.9785547869337731), 256)
+@test length(r2) == 256
 
 for X in ([0.0], [0.0,0.0], [0.0,0.5], [-0.5:0.1:0.5;])
     w = default_bandwidth(X)


### PR DESCRIPTION
KernelDensity.jl rolled its own range generator which suffers from similar flaws as Base's linspace prior to being fixed in JuliaLang/julia#18777. This closes #39. @andreasnoack @simonbyrne. This needed for https://github.com/GiovineItalia/Gadfly.jl/pull/1157

Master 
```julia
julia> length(KernelDensity.kde_range((0.12698109160784082, 0.9785547869337731), 256))
255
```

This PR
```julia
julia> length(KernelDensity.kde_range((0.12698109160784082, 0.9785547869337731), 256))
256
```