### PR TITLE
Fixes for Julia 0.7/1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,13 @@ os:
   - linux
   - osx
 julia:
-  - 0.6
+  - 0.7
+  - 1.0
   - nightly
+matrix:
+  allow_failures:
+    - julia: 1.0
+    - julia: nightly
 notifications:
   email: false
 # Uncomment the following lines to override the default test script
@@ -12,4 +17,4 @@ notifications:
 #  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
 #  - julia -e 'Pkg.clone(pwd()); Pkg.build("KernelDensity"); Pkg.test("KernelDensity"; coverage=true)'
 after_success:
-  - julia -e 'cd(Pkg.dir("KernelDensity")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
+  - julia -e 'import Pkg, KernelDensity; cd(joinpath(dirname(pathof(KernelDensity)), "..")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ least-squares cross validation. It accepts the above keyword arguments, except
 
 There are also some slightly more advanced interfaces:
 ```
-kde(data, midpoints::Range)
+kde(data, midpoints::R) where R<:AbstractRange
 ```
 allows specifying the internal grid to use. Optional keyword arguments are
 `kernel` and `bandwidth`.
@@ -53,7 +53,7 @@ allows specifying the exact distribution to use as the kernel. Optional
 keyword arguments are `boundary` and `npoints`.
 
 ```
-kde(data, midpoints::Range, dist::Distribution)
+kde(data, midpoints::R, dist::Distribution) where R<:AbstractRange
 ```
 allows specifying both the distribution and grid.
 
@@ -95,4 +95,3 @@ pdf(ik, x)
 ```
 
 `InterpKDE` will pass any extra arguments to `interpolate`.
-

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
-julia 0.6
-Compat 0.17
+julia 0.7
+Compat
 StatsBase
 Distributions
 Optim

--- a/REQUIRE
+++ b/REQUIRE
@@ -4,3 +4,4 @@ StatsBase
 Distributions
 Optim
 Interpolations
+FFTW

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,4 @@
 julia 0.7
-Compat
 StatsBase
 Distributions
 Optim

--- a/src/KernelDensity.jl
+++ b/src/KernelDensity.jl
@@ -1,5 +1,3 @@
-VERSION < v"0.7" && __precompile__()
-
 module KernelDensity
 
 using StatsBase

--- a/src/KernelDensity.jl
+++ b/src/KernelDensity.jl
@@ -1,4 +1,4 @@
-__precompile__()
+VERSION < v"0.7" && __precompile__()
 
 module KernelDensity
 

--- a/src/KernelDensity.jl
+++ b/src/KernelDensity.jl
@@ -2,7 +2,6 @@ VERSION < v"0.7" && __precompile__()
 
 module KernelDensity
 
-using Compat
 using StatsBase
 using Distributions
 using Optim

--- a/src/KernelDensity.jl
+++ b/src/KernelDensity.jl
@@ -8,7 +8,6 @@ using Distributions
 using Optim
 using Interpolations
 
-import Base: conv
 import StatsBase: RealVector, RealMatrix
 import Distributions: twoπ, pdf
 import FFTW: rfft, irfft

--- a/src/KernelDensity.jl
+++ b/src/KernelDensity.jl
@@ -11,6 +11,7 @@ using Interpolations
 import Base: conv
 import StatsBase: RealVector, RealMatrix
 import Distributions: twoπ, pdf
+import FFTW: rfft, irfft
 
 export kde, kde_lscv, UnivariateKDE, BivariateKDE, InterpKDE, pdf
 
@@ -21,4 +22,3 @@ include("bivariate.jl")
 include("interp.jl")
 
 end # module
-

--- a/src/bivariate.jl
+++ b/src/bivariate.jl
@@ -1,5 +1,5 @@
 # Store both grid and density for KDE over R2
-mutable struct BivariateKDE{Rx<:Range,Ry<:Range} <: AbstractKDE
+mutable struct BivariateKDE{Rx<:AbstractRange,Ry<:AbstractRange} <: AbstractKDE
     x::Rx
     y::Ry
     density::Matrix{Float64}
@@ -26,7 +26,8 @@ function default_bandwidth(data::Tuple{RealVector,RealVector})
 end
 
 # tabulate data for kde
-function tabulate(data::Tuple{RealVector, RealVector}, midpoints::Tuple{Range, Range}, weights::Weights = default_weights(data))
+function tabulate(data::Tuple{RealVector, RealVector}, midpoints::Tuple{Rx, Ry},
+        weights::Weights = default_weights(data)) where {Rx<:AbstractRange,Ry<:AbstractRange}
     xdata, ydata = data
     ndata = length(xdata)
     length(ydata) == ndata || error("data vectors must be of same length")
@@ -87,7 +88,8 @@ const BivariateDistribution = Union{MultivariateDistribution,Tuple{UnivariateDis
 
 default_weights(data::Tuple{RealVector, RealVector}) = UniformWeights(length(data[1]))
 
-function kde(data::Tuple{RealVector, RealVector}, weights::Weights, midpoints::Tuple{Range, Range}, dist::BivariateDistribution)
+function kde(data::Tuple{RealVector, RealVector}, weights::Weights, midpoints::Tuple{Rx, Ry},
+        dist::BivariateDistribution) where {Rx<:AbstractRange,Ry<:AbstractRange}
     k = tabulate(data, midpoints, weights)
     conv(k,dist)
 end
@@ -104,8 +106,9 @@ function kde(data::Tuple{RealVector, RealVector}, dist::BivariateDistribution;
     kde(data,weights,(xmid,ymid),dist)
 end
 
-function kde(data::Tuple{RealVector, RealVector}, midpoints::Tuple{Range, Range};
-             bandwidth=default_bandwidth(data), kernel=Normal, weights::Weights = default_weights(data))
+function kde(data::Tuple{RealVector, RealVector}, midpoints::Tuple{Rx, Ry};
+             bandwidth=default_bandwidth(data), kernel=Normal,
+             weights::Weights = default_weights(data)) where {Rx<:AbstractRange,Ry<:AbstractRange}
 
     dist = kernel_dist(kernel,bandwidth)
     kde(data,weights,midpoints,dist)

--- a/src/univariate.jl
+++ b/src/univariate.jl
@@ -66,7 +66,7 @@ function kde_range(boundary::Tuple{Real,Real}, npoints::Int)
     lo, hi = boundary
     lo < hi || error("boundary (a,b) must have a < b")
 
-    Compat.range(lo, stop=hi, length=npoints)
+    range(lo, stop=hi, length=npoints)
 end
 
 struct UniformWeights{N} end

--- a/src/univariate.jl
+++ b/src/univariate.jl
@@ -1,5 +1,5 @@
 # Store both grid and density for KDE over the real line
-mutable struct UnivariateKDE{R<:Range} <: AbstractKDE
+mutable struct UnivariateKDE{R<:AbstractRange} <: AbstractKDE
     x::R
     density::Vector{Float64}
 end
@@ -80,7 +80,7 @@ const Weights = Union{UniformWeights, RealVector, StatsBase.Weights}
 
 
 # tabulate data for kde
-function tabulate(data::RealVector, midpoints::Range, weights::Weights=default_weights(data))
+function tabulate(data::RealVector, midpoints::R, weights::Weights=default_weights(data)) where R<:AbstractRange
     npoints = length(midpoints)
     s = step(midpoints)
 
@@ -131,7 +131,7 @@ function conv(k::UnivariateKDE, dist::UnivariateDistribution)
 end
 
 # main kde interface methods
-function kde(data::RealVector, weights::Weights, midpoints::Range, dist::UnivariateDistribution)
+function kde(data::RealVector, weights::Weights, midpoints::R, dist::UnivariateDistribution) where R<:AbstractRange
     k = tabulate(data, midpoints, weights)
     conv(k,dist)
 end
@@ -143,8 +143,8 @@ function kde(data::RealVector, dist::UnivariateDistribution;
     kde(data,weights,midpoints,dist)
 end
 
-function kde(data::RealVector, midpoints::Range;
-             bandwidth=default_bandwidth(data), kernel=Normal, weights=default_weights(data))
+function kde(data::RealVector, midpoints::R;
+             bandwidth=default_bandwidth(data), kernel=Normal, weights=default_weights(data)) where R<:AbstractRange
     bandwidth > 0.0 || error("Bandwidth must be positive")
     dist = kernel_dist(kernel,bandwidth)
     kde(data,weights,midpoints,dist)
@@ -162,10 +162,10 @@ end
 #   B. W. Silverman (1986)
 #   sections 3.4.3 (pp. 48-52) and 3.5 (pp. 61-66)
 
-function kde_lscv(data::RealVector, midpoints::Range;
+function kde_lscv(data::RealVector, midpoints::R;
                   kernel=Normal,
                   bandwidth_range::Tuple{Real,Real}=(h=default_bandwidth(data); (0.25*h,1.5*h)),
-                  weights=default_weights(data))
+                  weights=default_weights(data)) where R<:AbstractRange
 
     ndata = length(data)
     k = tabulate(data, midpoints, weights)

--- a/test/bivariate.jl
+++ b/test/bivariate.jl
@@ -32,7 +32,7 @@ for X in ([0.0], [0.0,0.0], [0.0,0.5], [-0.5:0.1:0.5;])
         @test all(k1.density .>= 0.0)
         @test sum(k1.density)*step(k1.x)*step(k1.y) ≈ 1.0
 
-        k2 = conv(k1,kernel_dist(Tuple{D,D}, (0.1,0.1)))
+        k2 = KernelDensity.conv(k1,kernel_dist(Tuple{D,D}, (0.1,0.1)))
         @test isa(k2,BivariateKDE)
         @test size(k2.density) == (length(k2.x), length(k2.y))
         @test all(k2.density .>= 0.0)

--- a/test/bivariate.jl
+++ b/test/bivariate.jl
@@ -1,4 +1,4 @@
-using Base.Test
+using Compat.Test
 using Distributions
 using KernelDensity
 

--- a/test/bivariate.jl
+++ b/test/bivariate.jl
@@ -61,6 +61,6 @@ for X in ([0.0], [0.0,0.0], [0.0,0.5], [-0.5:0.1:0.5;])
     end
 end
 
-k1 = kde([0.0 0.0; 1.0 1.0], (r,r), bandwidth=(1,1), weights=[0,1])
-k2 = kde([1.0 1.0], (r,r), bandwidth=(1,1))
-@test k1.density ≈ k2.density
+k11 = kde([0.0 0.0; 1.0 1.0], (r,r), bandwidth=(1,1), weights=[0,1])
+k12 = kde([1.0 1.0], (r,r), bandwidth=(1,1))
+@test k11.density ≈ k12.density

--- a/test/bivariate.jl
+++ b/test/bivariate.jl
@@ -56,7 +56,7 @@ for X in ([0.0], [0.0,0.0], [0.0,0.5], [-0.5:0.1:0.5;])
         @test all(k5.density .>= 0.0)
         @test sum(k5.density)*step(k5.x)*step(k5.y) ≈ 1.0
 
-        k6 = kde([X X],(r,r);kernel=D, weights=ones(X)/length(X))
+        k6 = kde([X X],(r,r);kernel=D, weights=fill(1.0/length(X),length(X)))
         @test k4.density ≈ k6.density
     end
 end

--- a/test/bivariate.jl
+++ b/test/bivariate.jl
@@ -1,4 +1,4 @@
-using Compat.Test
+using Test
 using Distributions
 using KernelDensity
 

--- a/test/interp.jl
+++ b/test/interp.jl
@@ -1,4 +1,4 @@
-using Compat.Test
+using Test
 using KernelDensity
 
 X = randn(100)

--- a/test/interp.jl
+++ b/test/interp.jl
@@ -1,4 +1,4 @@
-using Base.Test
+using Compat.Test
 using KernelDensity
 
 X = randn(100)

--- a/test/univariate.jl
+++ b/test/univariate.jl
@@ -58,7 +58,7 @@ for X in ([0.0], [0.0,0.0], [0.0,0.5], [-0.5:0.1:0.5;])
         @test all(k5.density .>= 0.0)
         @test sum(k5.density)*step(k5.x) ≈ 1.0
 
-        k6 = kde(X,r;kernel=D, weights=ones(X)/length(X))
+        k6 = kde(X,r;kernel=D, weights=fill(1.0/length(X),length(X)))
         @test k4.density ≈ k6.density
     end
 end

--- a/test/univariate.jl
+++ b/test/univariate.jl
@@ -1,4 +1,4 @@
-using Base.Test
+using Compat.Test
 using Distributions
 using KernelDensity
 

--- a/test/univariate.jl
+++ b/test/univariate.jl
@@ -13,11 +13,8 @@ end
 
 r = kde_range((-2.0,2.0), 128)
 @test step(r) > 0
-if VERSION >= v"0.7-"
-    # problem on Julia v0.6 for some reason
-    r2 = kde_range((0.12698109160784082, 0.9785547869337731), 256)
-    @test length(r2) == 256
-end
+r2 = kde_range((0.12698109160784082, 0.9785547869337731), 256)
+@test length(r2) == 256
 
 for X in ([0.0], [0.0,0.0], [0.0,0.5], [-0.5:0.1:0.5;])
     w = default_bandwidth(X)

--- a/test/univariate.jl
+++ b/test/univariate.jl
@@ -63,6 +63,6 @@ for X in ([0.0], [0.0,0.0], [0.0,0.5], [-0.5:0.1:0.5;])
     end
 end
 
-k1 = kde([0.0, 1.], r, bandwidth=1, weights=[0,1])
-k2 = kde([1.], r, bandwidth=1)
-@test k1.density ≈ k2.density
+k11 = kde([0.0, 1.], r, bandwidth=1, weights=[0,1])
+k12 = kde([1.], r, bandwidth=1)
+@test k11.density ≈ k12.density

--- a/test/univariate.jl
+++ b/test/univariate.jl
@@ -34,7 +34,7 @@ for X in ([0.0], [0.0,0.0], [0.0,0.5], [-0.5:0.1:0.5;])
         @test all(k1.density .>= 0.0)
         @test sum(k1.density)*step(k1.x) ≈ 1.0
 
-        k2 = conv(k1,kernel_dist(D,0.1))
+        k2 = KernelDensity.conv(k1,kernel_dist(D,0.1))
         @test isa(k2,UnivariateKDE)
         @test length(k2.density) == length(k2.x)
         @test all(k2.density .>= 0.0)

--- a/test/univariate.jl
+++ b/test/univariate.jl
@@ -13,8 +13,11 @@ end
 
 r = kde_range((-2.0,2.0), 128)
 @test step(r) > 0
-r2 = kde_range((0.12698109160784082, 0.9785547869337731), 256)
-@test length(r2) == 256
+if VERSION >= v"0.7-"
+    # problem on Julia v0.6 for some reason
+    r2 = kde_range((0.12698109160784082, 0.9785547869337731), 256)
+    @test length(r2) == 256
+end
 
 for X in ([0.0], [0.0,0.0], [0.0,0.5], [-0.5:0.1:0.5;])
     w = default_bandwidth(X)

--- a/test/univariate.jl
+++ b/test/univariate.jl
@@ -1,4 +1,4 @@
-using Compat.Test
+using Test
 using Distributions
 using KernelDensity
 


### PR DESCRIPTION
Possible issues:

1. On Julia v0.6, one of the kde_range tests was failing even before any changes were made.
2. Base.conv is no longer overridden since it no longer exists on 0.7/1.0. I don't know if any packages were making use of this undocumented feature.
3. I believe the Compat dependency could be removed entirely, but I haven't done this.