### PR TITLE
Add lower bound to REQUIRE: Optim

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ julia:
   - nightly
 matrix:
   allow_failures:
-    - julia: 1.0
     - julia: nightly
 notifications:
   email: false

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,6 @@
 julia 0.7
 StatsBase
 Distributions
-Optim
+Optim 0.16
 Interpolations
 FFTW


### PR DESCRIPTION
As requested by @andreasnoack : https://github.com/JuliaLang/METADATA.jl/pull/16625

Also now disallows travis failures on julia v1.0.