### PR TITLE
Support Interpolations v0.9

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,5 +2,5 @@ julia 0.7
 StatsBase
 Distributions
 Optim 0.16
-Interpolations
+Interpolations 0.9 0.10-
 FFTW

--- a/src/interp.jl
+++ b/src/interp.jl
@@ -12,7 +12,7 @@ function InterpKDE(kde::UnivariateKDE, opts...)
     itp = scale(itp_u, kde.x)
     InterpKDE{typeof(kde),typeof(itp)}(kde, itp)
 end
-InterpKDE(kde::UnivariateKDE) = InterpKDE(kde, BSpline(Quadratic(Line())), OnGrid())
+InterpKDE(kde::UnivariateKDE) = InterpKDE(kde, BSpline(Quadratic(Line(OnGrid()))))
 
 
 function InterpKDE(kde::BivariateKDE, opts...)
@@ -20,7 +20,7 @@ function InterpKDE(kde::BivariateKDE, opts...)
     itp = scale(itp_u, kde.x, kde.y)
     InterpKDE{typeof(kde),typeof(itp)}(kde, itp)
 end
-InterpKDE(kde::BivariateKDE) = InterpKDE(kde::BivariateKDE, BSpline(Quadratic(Line())), OnGrid())
+InterpKDE(kde::BivariateKDE) = InterpKDE(kde::BivariateKDE, BSpline(Quadratic(Line(OnGrid()))))
 
 pdf(ik::InterpKDE,x::Real...) = ik.itp(x...)
 pdf(ik::InterpKDE,xs::AbstractVector) = [ik.itp(x) for x in xs]

--- a/src/interp.jl
+++ b/src/interp.jl
@@ -10,7 +10,8 @@ end
 function InterpKDE(kde::UnivariateKDE, opts...)
     itp_u = interpolate(kde.density, opts...)
     itp = scale(itp_u, kde.x)
-    InterpKDE{typeof(kde),typeof(itp)}(kde, itp)
+    etp = extrapolate(itp, zero(eltype(kde.density)))
+    InterpKDE{typeof(kde),typeof(etp)}(kde, etp)
 end
 InterpKDE(kde::UnivariateKDE) = InterpKDE(kde, BSpline(Quadratic(Line(OnGrid()))))
 
@@ -18,7 +19,8 @@ InterpKDE(kde::UnivariateKDE) = InterpKDE(kde, BSpline(Quadratic(Line(OnGrid()))
 function InterpKDE(kde::BivariateKDE, opts...)
     itp_u = interpolate(kde.density,opts...)
     itp = scale(itp_u, kde.x, kde.y)
-    InterpKDE{typeof(kde),typeof(itp)}(kde, itp)
+    etp = extrapolate(itp, zero(eltype(kde.density)))
+    InterpKDE{typeof(kde),typeof(etp)}(kde, etp)
 end
 InterpKDE(kde::BivariateKDE) = InterpKDE(kde::BivariateKDE, BSpline(Quadratic(Line(OnGrid()))))
 

--- a/src/interp.jl
+++ b/src/interp.jl
@@ -22,9 +22,9 @@ function InterpKDE(kde::BivariateKDE, opts...)
 end
 InterpKDE(kde::BivariateKDE) = InterpKDE(kde::BivariateKDE, BSpline(Quadratic(Line())), OnGrid())
 
-pdf(ik::InterpKDE,x::Real...) = ik.itp[x...]
-pdf(ik::InterpKDE,xs::AbstractVector) = [ik.itp[x] for x in xs]
-pdf(ik::InterpKDE,xs::AbstractVector,ys::AbstractVector) = [ik.itp[x,y] for x in xs, y in ys]
+pdf(ik::InterpKDE,x::Real...) = ik.itp(x...)
+pdf(ik::InterpKDE,xs::AbstractVector) = [ik.itp(x) for x in xs]
+pdf(ik::InterpKDE,xs::AbstractVector,ys::AbstractVector) = [ik.itp(x,y) for x in xs, y in ys]
 
 pdf(k::UnivariateKDE,x) = pdf(InterpKDE(k),x)
 pdf(k::BivariateKDE,x,y) = pdf(InterpKDE(k),x,y)

--- a/test/interp.jl
+++ b/test/interp.jl
@@ -9,3 +9,17 @@ k = kde(X)
 
 k = kde((X,Y))
 @test pdf(k, k.x, k.y) ≈ k.density
+
+# Try to evaluate the KDE outside the interpolation domain
+# The KDE is allowed to be zero, but it should not be greater than the exact solution
+k = kde([0.0], bandwidth=1.0)
+@test pdf(k, k.x) ≈ k.density
+@test pdf(k, -10.0) ≤ pdf(Normal(), -10.0)
+@test pdf(k, +10.0) ≤ pdf(Normal(), +10.0)
+
+k = kde(([0.0],[0.0]), bandwidth=(1.0, 1.0))
+@test pdf(k, k.x, k.y) ≈ k.density
+@test pdf(k, -10.0, 0.0) ≤ pdf(MvNormal(2, 1.0), [-10.0, 0.0])
+@test pdf(k, +10.0, 0.0) ≤ pdf(MvNormal(2, 1.0), [+10.0, 0.0])
+@test pdf(k, 0.0, -10.0) ≤ pdf(MvNormal(2, 1.0), [0.0, -10.0])
+@test pdf(k, 0.0, +10.0) ≤ pdf(MvNormal(2, 1.0), [0.0, +10.0])


### PR DESCRIPTION
This PR fixes #60 and removes deprecations warnings introduced with Interpolations 0.9. I have also added a few trivial regression tests.

I have tentatively added version bounds for Interpolations to avoid unwanted breakage in the future. So we will need to manually bump the upper bound after having checked that the new version works (and until Interpolations publishes a stable release). The downside is that we now require Interpolations >=0.9.

This PR does not break the KernelDensity API itself.

Let me know if you have comments or suggestions (e.g. if you want to continue supporting older versions of Interpolations). I may have forgotten to update the code in some places, so it would be nice if someone who is familiar with KernelDensity could double-check that.