### PR TITLE
Raise upper version bound for Interpolations to v0.10.x

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,5 +2,5 @@ julia 0.7
 StatsBase
 Distributions
 Optim 0.16
-Interpolations 0.9 0.10-
+Interpolations 0.9 0.11-
 FFTW


### PR DESCRIPTION
Fix issue mentioned in [METADATA.jl#19114](https://github.com/JuliaLang/METADATA.jl/pull/19114#issuecomment-433161312).
See also discussion in #61.