### PR TITLE
relaxed types for use with Array{TrackedReal}

### DIFF
--- a/src/bivariate.jl
+++ b/src/bivariate.jl
@@ -19,7 +19,7 @@ mutable struct BivariateKDE{Rx<:AbstractRange,Ry<:AbstractRange} <: AbstractKDE
     "Second coordinate of gridpoints for evaluating the density."
     y::Ry
     "Kernel density at corresponding gridpoints `Tuple.(x, permutedims(y))`."
-    density::Matrix{Float64}
+    density::AbstractMatrix{}
 end
 
 function kernel_dist(::Type{D},w::Tuple{Real,Real}) where D<:UnivariateDistribution
@@ -54,7 +54,7 @@ function tabulate(data::Tuple{RealVector, RealVector}, midpoints::Tuple{Rx, Ry},
     sx, sy = step(xmid), step(ymid)
 
     # Set up a grid for discretized data
-    grid = zeros(Float64, nx, ny)
+    grid = zeros(eltype(xdata),nx,ny)
     ainc = 1.0 / (sum(weights)*(sx*sy)^2)
 
     # weighted discretization (cf. Jones and Lotwick)

--- a/src/univariate.jl
+++ b/src/univariate.jl
@@ -17,7 +17,7 @@ mutable struct UnivariateKDE{R<:AbstractRange} <: AbstractKDE
     "Gridpoints for evaluating the density."
     x::R
     "Kernel density at corresponding gridpoints `x`."
-    density::Vector{Float64}
+    density::AbstractVector{}
 end
 
 # construct kernel from bandwidth
@@ -101,7 +101,7 @@ function tabulate(data::RealVector, midpoints::R, weights::Weights=default_weigh
     s = step(midpoints)
 
     # Set up a grid for discretized data
-    grid = zeros(Float64, npoints)
+    grid = zeros(eltype(data),npoints)
     ainc = 1.0 / (sum(weights)*s*s)
 
     # weighted discretization (cf. Jones and Lotwick)


### PR DESCRIPTION
this is the only change that is necessary to make kdes differentiable. All other patches are contained in `https://github.com/gszep/FluxContinuation/blob/master/patches/KernelDensity.jl` 