### PR TITLE
Remove optim in favor of independent golden section implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 examples/.ipynb_checkpoints/*
+Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -8,12 +8,10 @@ Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
-Optim = "429524aa-4258-5aef-a3af-852621145aeb"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
 Interpolations = "≥ 0.9"
-Optim = "≥ 0.16"
 julia = "^1"
 
 [extras]

--- a/src/KernelDensity.jl
+++ b/src/KernelDensity.jl
@@ -3,7 +3,6 @@ module KernelDensity
 using DocStringExtensions: TYPEDEF, FIELDS
 using StatsBase
 using Distributions
-using Optim
 using Interpolations
 
 import StatsBase: RealVector, RealMatrix

--- a/src/univariate.jl
+++ b/src/univariate.jl
@@ -173,44 +173,42 @@ function kde(data::RealVector; bandwidth=default_bandwidth(data), kernel=Normal,
     kde(data,dist;boundary=boundary,npoints=npoints,weights=weights)
 end
 
-function optimize(f, x_lower, x_upper)
-    
+function optimize(f, x_lower, x_upper; iterations=1000, rel_tol=nothing, abs_tol=nothing)
+
     if x_lower > x_upper
         error("x_lower must be less than x_upper")
     end
 
     T = promote_type(typeof(x_lower/1), typeof(x_upper/1))
-
-    rel_tol::T=sqrt(eps(T))
-    abs_tol::T=eps(T)
-    iterations=1000
-
+    rtol = something(rel_tol, sqrt(eps(T)))
+    atol = something(abs_tol, eps(T))
+    
+    function acceptable_interval(lower, upper)
+        midpoint = (lower + upper) / 2
+        tol = atol + rtol * midpoint
+        return (upper - lower) <= 2tol
+    end
+    
     invphi::T = 0.5 * (sqrt(5) - 1)
     invphisq::T = 0.5 * (3 - sqrt(5))
-
+    
     a::T, b::T = x_lower, x_upper
     h = b - a
     c = a + invphisq * h
     d = a + invphi * h
-
-    fc, fd = f(c), f(d)
-
-    function tolerable_interval(lower, upper)
-        midpoint = (lower + upper) / 2
-        tol = abs_tol + rel_tol * abs(midpoint)
-        return (upper - lower) <= 2tol
-    end
     
-    for _ in 1:iterations
-        h = invphi * h
+    fc, fd = f(c), f(d)
+    
+    for _ in 1:1000
+        h *= invphi
         if fc < fd
-            tolerable_interval(a, d) && break
+            acceptable_interval(a, d) && break
             b = d
             d, fd = c, fc
             c = a + invphisq * h
             fc = f(c)
         else
-            tolerable_interval(c, b) && break
+            acceptable_interval(c, b) && break
             a = c
             c, fc = d, fd
             d = a + invphi * h

--- a/src/univariate.jl
+++ b/src/univariate.jl
@@ -173,6 +173,28 @@ function kde(data::RealVector; bandwidth=default_bandwidth(data), kernel=Normal,
     kde(data,dist;boundary=boundary,npoints=npoints,weights=weights)
 end
 
+"""
+    optimize(f, x_lower, x_upper; iterations=1000, rel_tol=nothing, abs_tol=nothing)
+
+Minimize the function `f` in the interval `x_lower..x_upper`, using the
+[golden-section search](https://en.wikipedia.org/wiki/Golden-section_search).
+Return an approximate minimum `x̃` or error if such approximate minimum cannot be found.
+
+This algorithm assumes that `-f` is unimodal on the interval `x_lower..x_upper`,
+that is to say, there exists a unique `x` in `x_lower..x_upper` such that `f` is
+decreasing on `x_lower..x` and increasing on `x..x_upper`.
+
+`rel_tol` and `abs_tol` determine the relative and absolute tolerance, that is
+to say, the returned value `x̃` should differ from the actual minimum `x` at most
+`abs_tol + rel_tol * abs(x̃)`.
+If not manually specified, `rel_tol` and `abs_tol` default to `sqrt(eps(T))` and
+`eps(T)` respectively, where `T` is the floating point type of `x_lower` and `x_upper`.
+
+`iterations` determines the maximum number of iterations allowed before convergence.
+
+This is a private, unexported function, used internally to select the optimal bandwidth
+automatically.
+"""
 function optimize(f, x_lower, x_upper; iterations=1000, rel_tol=nothing, abs_tol=nothing)
 
     if x_lower > x_upper

--- a/test/univariate.jl
+++ b/test/univariate.jl
@@ -63,3 +63,9 @@ end
 k11 = kde([0.0, 1.], r, bandwidth=1, weights=[0,1])
 k12 = kde([1.], r, bandwidth=1)
 @test k11.density ≈ k12.density
+
+rel_tol = sqrt(eps(Float64))
+abs_tol = eps(Float64)
+
+minimizer = KernelDensity.optimize(x -> (x - 1)^2, 0, 2)
+@test abs(minimizer - 1) <= abs_tol + rel_tol * abs(minimizer)

--- a/test/univariate.jl
+++ b/test/univariate.jl
@@ -67,5 +67,5 @@ k12 = kde([1.], r, bandwidth=1)
 rel_tol = sqrt(eps(Float64))
 abs_tol = eps(Float64)
 
-minimizer = KernelDensity.optimize(x -> (x - 1)^2, 0, 2)
+minimizer = @inferred KernelDensity.optimize(x -> (x - 1)^2, 0, 2)
 @test abs(minimizer - 1) <= abs_tol + rel_tol * abs(minimizer)


### PR DESCRIPTION
Fix #83. This adds a simple implementation of the [golden section algorithm](https://en.wikipedia.org/wiki/Golden-section_search), so that KernelDensity can drop the Optim dependency. The issue (at least for me) is that Optim is somewhat heavy (3 seconds of load time), and KernelDensity is needed as a dependency for plotting packages for 1D and 2D density plots, so ideally it should be a bit more lightweight.

Removing Optim shaves off a couple of seconds from load time.

On master:

```julia
julia> @time using KernelDensity
  6.803513 seconds (12.15 M allocations: 706.212 MiB, 2.90% gc time)
```

With this PR:

```julia
julia> @time using KernelDensity
  4.620525 seconds (7.87 M allocations: 475.978 MiB, 0.72% gc time)
```