### PR TITLE
Give UnivariateKDE distribution-like overloads

### DIFF
--- a/src/univariate.jl
+++ b/src/univariate.jl
@@ -20,6 +20,10 @@ mutable struct UnivariateKDE{R<:AbstractRange} <: AbstractKDE
     density::Vector{Float64}
 end
 
+Base.eltype(K::UnivariateKDE)  = eltype(K.density)
+Base.minimum(K::UnivariateKDE) = minimum(K.x)
+Base.maximum(K::UnivariateKDE) = maximum(K.x)
+
 # construct kernel from bandwidth
 kernel_dist(::Type{Normal},w::Real) = Normal(0.0,w)
 kernel_dist(::Type{Uniform},w::Real) = (s = 1.7320508075688772*w; Uniform(-s,s))


### PR DESCRIPTION
Upstreams https://github.com/SciML/DiffEqUncertainty.jl/pull/41 . Allows for it to be "distribution-like". Still missing the random sampling.