### PR TITLE
Switch from FFTW to FastTransforms to avoid GPL

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,14 +6,13 @@ version = "0.6.2"
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
-FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
+FastTransforms = "057dd010-8810-581a-b7be-e3fc3b93f78c"
 Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
 Distributions = "0.23, 0.24"
 DocStringExtensions = "0.8"
-FFTW = "1"
 Interpolations = "0.9, 0.10, 0.11, 0.12, 0.13"
 StatsBase = "0.33"
 julia = "1"

--- a/src/KernelDensity.jl
+++ b/src/KernelDensity.jl
@@ -7,7 +7,7 @@ using Interpolations
 
 import StatsBase: RealVector, RealMatrix
 import Distributions: twoπ, pdf
-import FFTW: rfft, irfft
+import FastTransforms: rfft, irfft
 
 export kde, kde_lscv, UnivariateKDE, BivariateKDE, InterpKDE, pdf
 


### PR DESCRIPTION
This avoids a GPL dependency and therefore will make it easier to integrate KernelDensity into non-GPL projects.