### PR TITLE
allow matrix as input for bivariate kde

### DIFF
--- a/src/interp.jl
+++ b/src/interp.jl
@@ -30,3 +30,5 @@ pdf(ik::InterpKDE,xs::AbstractVector,ys::AbstractVector) = [ik.itp(x,y) for x in
 
 pdf(k::UnivariateKDE,x) = pdf(InterpKDE(k),x)
 pdf(k::BivariateKDE,x,y) = pdf(InterpKDE(k),x,y)
+pdf(k::BivariateKDE,x::AbstractMatrix) = pdf(InterpKDE(k),x[:,1],x[:,2])
+


### PR DESCRIPTION
Since the estimate of bivariate kde allow matrix as input, e.g.,
```julia
x = randn(100, 2)
f = kde(x)
```
it would be more convenient when evaluating at x by `pdf(f, x)` than `pdf(f, x[:, 1], x[:,2])`