### PR TITLE
Use AbstractFFTs instead of FFTW

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
-AbstractFFTs = "1"
+AbstractFFTs = "0.5, 1"
 Distributions = "0.23, 0.24, 0.25"
 DocStringExtensions = "0.8, 0.9"
 Interpolations = "0.9, 0.10, 0.11, 0.12, 0.13, 0.14"

--- a/Project.toml
+++ b/Project.toml
@@ -1,25 +1,26 @@
 name = "KernelDensity"
 uuid = "5ab0869b-81aa-558d-bb23-cbf5423bbe9b"
 authors = ["Simon Byrne and various contributors"]
-version = "0.6.7"
+version = "0.7.0"
 
 [deps]
+AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
-FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
+AbstractFFTs = "1"
 Distributions = "0.23, 0.24, 0.25"
 DocStringExtensions = "0.8, 0.9"
-FFTW = "1"
 Interpolations = "0.9, 0.10, 0.11, 0.12, 0.13, 0.14"
 StatsBase = "0.33, 0.34"
 julia = "1"
 
 [extras]
+FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["FFTW", "Test"]

--- a/README.md
+++ b/README.md
@@ -7,6 +7,15 @@ Kernel density estimators for Julia.
 
 ## Usage
 
+### Prerequisite
+
+The kernel density estimates are computed with fast Fourier transforms (FFTs) internally using the [AbstractFFTs.jl](https://github.com/JuliaMath/AbstractFFTs.jl) interface.
+You have to load a backend such as [FFTW.jl](https://github.com/JuliaMath/FFTW.jl) that implements this interface:
+
+```julia
+using FFTW
+```
+
 ### Univariate
 The main accessor function is `kde`:
 

--- a/src/KernelDensity.jl
+++ b/src/KernelDensity.jl
@@ -6,7 +6,7 @@ using Distributions
 using Interpolations
 
 import Distributions: twoπ, pdf
-import FFTW: rfft, irfft
+using AbstractFFTs: rfft, irfft
 
 export kde, kde_lscv, UnivariateKDE, BivariateKDE, InterpKDE, pdf
 

--- a/test/bivariate.jl
+++ b/test/bivariate.jl
@@ -1,6 +1,7 @@
 using Test
 using Distributions
 using KernelDensity
+using FFTW
 
 import KernelDensity: kernel_dist, default_bandwidth, kde_boundary, kde_range, tabulate
 

--- a/test/interp.jl
+++ b/test/interp.jl
@@ -1,5 +1,6 @@
 using Test
 using KernelDensity
+using FFTW
 
 X = randn(100)
 Y = randn(100)

--- a/test/univariate.jl
+++ b/test/univariate.jl
@@ -1,6 +1,7 @@
 using Test
 using Distributions
 using KernelDensity
+using FFTW
 
 import KernelDensity: kernel_dist, default_bandwidth, kde_boundary, kde_range, tabulate
 


### PR DESCRIPTION
The AbstractFFTs interface is a bit special: The only way to select a backend such as FFTW or RustFFT is to load the desired backend package (see e.g. https://github.com/JuliaMath/AbstractFFTs.jl/issues/32 and the discussion in https://github.com/JuliaPlots/StatsPlots.jl/pull/480). In particular, as noted in https://github.com/JuliaPlots/StatsPlots.jl/pull/480#issuecomment-1022370329 this means that

>  Once one of the packages that implements the interface is loaded, there's no way for the user to switch between them, and the whole point of the interface package is to not coerce the user to a choice.

Generally, that seems to be a questionable design decision to me. However, until the design is changed, IMO KernelDensity.jl should follow it and not enforce the use of FFTW.jl throughout the ecosystem, in particular since nowadays different backends such as FFTW.jl, GenericFFTs.jl, and RustFFT.jl (real FFTs planned but not supported yet) exist. Even more so since the GPL-license of FFTW can be problematic and MKL alternative is a large lazy artifact and missing support for e.g. recent Macs with Apple silicon.