### PR TITLE
Update CI build matrix

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,9 +13,10 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
-          - '1'
-          - 'nightly'
+          - 'min'
+          - 'lts'
+          - 'release'
+          - 'pre'
         os:
           - ubuntu-latest
         arch:


### PR DESCRIPTION
To use `min`, `lts`, `release`, and `pre`. This should make it easier to test on relevant versions and avoid unrelated failures from nightly.