### PR TITLE
Univariate and Bivariate KDE objects had opposite docstrings whe

### DIFF
--- a/src/bivariate.jl
+++ b/src/bivariate.jl
@@ -1,7 +1,7 @@
 """
 $(TYPEDEF)
 
-Store both grid and density for KDE over the real line.
+Store both grid and density for KDE over ``ℝ²``.
 
 Reading the fields directly is part of the API, and
 

--- a/src/univariate.jl
+++ b/src/univariate.jl
@@ -1,7 +1,7 @@
 """
 $(TYPEDEF)
 
-Store both grid and density for KDE over ``ℝ²``.
+Store both grid and density for KDE over the real line.
 
 Reading the fields directly is part of the API, and
 


### PR DESCRIPTION
This was in the docstring for `UnivariateKDE`, and the reverse for `BivariateKDE`. I switched them back to correct the documentation.
```
Store both grid and density for KDE over ``ℝ²``.
```